### PR TITLE
chore(license): add CC-BY-4.0 LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Creative Commons Attribution 4.0 International License
+
+Copyright (c) 2026 Kol Tregaskes
+
+This work is licensed under the Creative Commons Attribution 4.0 International License.
+To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/
+or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+Full legal text: https://creativecommons.org/licenses/by/4.0/legalcode


### PR DESCRIPTION
Content-heavy site — CC-BY-4.0 lets others share/adapt with attribution. Closes missing-LICENSE gap from 2026-05-19 audit.