### PR TITLE
fix: extend Axy footer to support pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,6 +30,45 @@
         <p class="error-text">This page doesn't exist. Head back to the gallery or explore the tools and rankings.</p>
         <a href="index.html" class="error-link">Back to Axy Lusion</a>
     </main>
+    <footer>
+        <div class="footer-content">
+            <div class="footer-brand">
+                <span class="footer-logo">Axy Lusion</span>
+                <p class="footer-tagline">AI Art, Video &amp; Music</p>
+            </div>
+            <nav class="footer-group" aria-label="Main pages">
+                <span>Main</span>
+                <a href="gallery.html">Gallery</a>
+                <a href="videos.html">Videos</a>
+                <a href="music.html">Music</a>
+                <a href="blog.html">Blog</a>
+                <a href="news.html">News</a>
+            </nav>
+            <nav class="footer-group" aria-label="Projects">
+                <span>Projects</span>
+                <a href="tools.html">Tools</a>
+                <a href="a-list.html">A-List</a>
+                <a href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                <a href="https://theairesourcehub.com/" target="_blank" rel="noopener noreferrer">AI Resource Hub</a>
+            </nav>
+            <nav class="footer-group" aria-label="Contact">
+                <span>Contact</span>
+                <a href="about.html">About</a>
+                <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a>
+                <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer">X / Twitter</a>
+                <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer">Instagram</a>
+            </nav>
+            <p class="footer-copyright">&copy; 2026 <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a></p>
+            <section class="footer-estate-panel" aria-label="Elusion Works umbrella">
+                <div>
+                    <span>Umbrella home</span>
+                    <a class="footer-estate-title" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                </div>
+                <p>The showcase for Kol's websites, tools, games, and web experiments.</p>
+                <a class="footer-estate-cta" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Visit Elusion Works -&gt;</a>
+            </section>
+        </div>
+    </footer>
     <script src="cross-site-nav.js" defer></script>
 </body>
 </html>

--- a/blog-welcome.html
+++ b/blog-welcome.html
@@ -108,6 +108,28 @@
                 <span class="footer-logo">Axy Lusion</span>
                 <p class="footer-tagline">AI Art, Video &amp; Music</p>
             </div>
+            <nav class="footer-group" aria-label="Main pages">
+                <span>Main</span>
+                <a href="gallery.html">Gallery</a>
+                <a href="videos.html">Videos</a>
+                <a href="music.html">Music</a>
+                <a href="blog.html">Blog</a>
+                <a href="news.html">News</a>
+            </nav>
+            <nav class="footer-group" aria-label="Projects">
+                <span>Projects</span>
+                <a href="tools.html">Tools</a>
+                <a href="a-list.html">A-List</a>
+                <a href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                <a href="https://theairesourcehub.com/" target="_blank" rel="noopener noreferrer">AI Resource Hub</a>
+            </nav>
+            <nav class="footer-group" aria-label="Contact">
+                <span>Contact</span>
+                <a href="about.html">About</a>
+                <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a>
+                <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer">X / Twitter</a>
+                <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer">Instagram</a>
+            </nav>
             <nav class="social-links">
                 <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer" title="X / Twitter" aria-label="X"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
                 <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer" title="Instagram" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
@@ -117,6 +139,14 @@
                 <a href="https://suno.com/@axylusion" target="_blank" rel="noopener noreferrer" title="Suno" aria-label="Suno"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.5 14.5c0 .83-.67 1.5-1.5 1.5h-4c-.83 0-1.5-.67-1.5-1.5v-1c0-.83.67-1.5 1.5-1.5H14v-2h-4v1H8v-1c0-.83.67-1.5 1.5-1.5h4c.83 0 1.5.67 1.5 1.5v1c0 .83-.67 1.5-1.5 1.5H10v2h4v-1h1.5v1z"/></svg></a>
             </nav>
             <p class="footer-copyright">&copy; 2026 <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a></p>
+            <section class="footer-estate-panel" aria-label="Elusion Works umbrella">
+                <div>
+                    <span>Umbrella home</span>
+                    <a class="footer-estate-title" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                </div>
+                <p>The showcase for Kol's websites, tools, games, and web experiments.</p>
+                <a class="footer-estate-cta" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Visit Elusion Works -&gt;</a>
+            </section>
         </div>
     </footer>
     <script src="cross-site-nav.js" defer></script>

--- a/music.html
+++ b/music.html
@@ -135,8 +135,30 @@
         <div class="footer-content">
             <div class="footer-brand">
                 <span class="footer-logo">Axy Lusion</span>
-                <p class="footer-tagline">AI Art, Video & Music</p>
+                <p class="footer-tagline">AI Art, Video &amp; Music</p>
             </div>
+            <nav class="footer-group" aria-label="Main pages">
+                <span>Main</span>
+                <a href="gallery.html">Gallery</a>
+                <a href="videos.html">Videos</a>
+                <a href="music.html">Music</a>
+                <a href="blog.html">Blog</a>
+                <a href="news.html">News</a>
+            </nav>
+            <nav class="footer-group" aria-label="Projects">
+                <span>Projects</span>
+                <a href="tools.html">Tools</a>
+                <a href="a-list.html">A-List</a>
+                <a href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                <a href="https://theairesourcehub.com/" target="_blank" rel="noopener noreferrer">AI Resource Hub</a>
+            </nav>
+            <nav class="footer-group" aria-label="Contact">
+                <span>Contact</span>
+                <a href="about.html">About</a>
+                <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a>
+                <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer">X / Twitter</a>
+                <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer">Instagram</a>
+            </nav>
             <nav class="social-links">
                 <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer" title="X / Twitter" aria-label="X"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
                 <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer" title="Instagram" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
@@ -146,6 +168,14 @@
                 <a href="https://suno.com/@axylusion" target="_blank" rel="noopener noreferrer" title="Suno" aria-label="Suno"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.5 14.5c0 .83-.67 1.5-1.5 1.5h-4c-.83 0-1.5-.67-1.5-1.5v-1c0-.83.67-1.5 1.5-1.5H14v-2h-4v1H8v-1c0-.83.67-1.5 1.5-1.5h4c.83 0 1.5.67 1.5 1.5v1c0 .83-.67 1.5-1.5 1.5H10v2h4v-1h1.5v1z"/></svg></a>
             </nav>
             <p class="footer-copyright">&copy; 2026 <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a></p>
+            <section class="footer-estate-panel" aria-label="Elusion Works umbrella">
+                <div>
+                    <span>Umbrella home</span>
+                    <a class="footer-estate-title" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                </div>
+                <p>The showcase for Kol's websites, tools, games, and web experiments.</p>
+                <a class="footer-estate-cta" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Visit Elusion Works -&gt;</a>
+            </section>
         </div>
     </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -2350,7 +2350,7 @@ footer {
     max-width: 1200px;
     margin: 0 auto;
     display: grid;
-    grid-template-columns: minmax(0, 1.25fr) repeat(3, minmax(150px, 1fr)) auto;
+    grid-template-columns: minmax(0, 1.1fr) repeat(3, minmax(140px, 1fr)) minmax(190px, auto);
     gap: var(--space-xl);
     align-items: start;
 }
@@ -2375,7 +2375,8 @@ footer {
 }
 
 .footer-copyright {
-    margin-top: var(--space-md);
+    grid-column: 1 / -1;
+    margin-top: 0;
 }
 
 .footer-group {

--- a/tools.html
+++ b/tools.html
@@ -422,8 +422,30 @@
         <div class="footer-content">
             <div class="footer-brand">
                 <span class="footer-logo">Axy Lusion</span>
-                <p class="footer-tagline">AI Art, Video & Music</p>
+                <p class="footer-tagline">AI Art, Video &amp; Music</p>
             </div>
+            <nav class="footer-group" aria-label="Main pages">
+                <span>Main</span>
+                <a href="gallery.html">Gallery</a>
+                <a href="videos.html">Videos</a>
+                <a href="music.html">Music</a>
+                <a href="blog.html">Blog</a>
+                <a href="news.html">News</a>
+            </nav>
+            <nav class="footer-group" aria-label="Projects">
+                <span>Projects</span>
+                <a href="tools.html">Tools</a>
+                <a href="a-list.html">A-List</a>
+                <a href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                <a href="https://theairesourcehub.com/" target="_blank" rel="noopener noreferrer">AI Resource Hub</a>
+            </nav>
+            <nav class="footer-group" aria-label="Contact">
+                <span>Contact</span>
+                <a href="about.html">About</a>
+                <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a>
+                <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer">X / Twitter</a>
+                <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer">Instagram</a>
+            </nav>
             <nav class="social-links">
                 <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer" title="X / Twitter" aria-label="X"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
                 <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer" title="Instagram" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
@@ -433,6 +455,14 @@
                 <a href="https://suno.com/@axylusion" target="_blank" rel="noopener noreferrer" title="Suno" aria-label="Suno"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.5 14.5c0 .83-.67 1.5-1.5 1.5h-4c-.83 0-1.5-.67-1.5-1.5v-1c0-.83.67-1.5 1.5-1.5H14v-2h-4v1H8v-1c0-.83.67-1.5 1.5-1.5h4c.83 0 1.5.67 1.5 1.5v1c0 .83-.67 1.5-1.5 1.5H10v2h4v-1h1.5v1z"/></svg></a>
             </nav>
             <p class="footer-copyright">&copy; 2026 <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a></p>
+            <section class="footer-estate-panel" aria-label="Elusion Works umbrella">
+                <div>
+                    <span>Umbrella home</span>
+                    <a class="footer-estate-title" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                </div>
+                <p>The showcase for Kol's websites, tools, games, and web experiments.</p>
+                <a class="footer-estate-cta" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Visit Elusion Works -&gt;</a>
+            </section>
         </div>
     </footer>
 

--- a/videos.html
+++ b/videos.html
@@ -147,8 +147,30 @@
         <div class="footer-content">
             <div class="footer-brand">
                 <span class="footer-logo">Axy Lusion</span>
-                <p class="footer-tagline">AI Art, Video & Music</p>
+                <p class="footer-tagline">AI Art, Video &amp; Music</p>
             </div>
+            <nav class="footer-group" aria-label="Main pages">
+                <span>Main</span>
+                <a href="gallery.html">Gallery</a>
+                <a href="videos.html">Videos</a>
+                <a href="music.html">Music</a>
+                <a href="blog.html">Blog</a>
+                <a href="news.html">News</a>
+            </nav>
+            <nav class="footer-group" aria-label="Projects">
+                <span>Projects</span>
+                <a href="tools.html">Tools</a>
+                <a href="a-list.html">A-List</a>
+                <a href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                <a href="https://theairesourcehub.com/" target="_blank" rel="noopener noreferrer">AI Resource Hub</a>
+            </nav>
+            <nav class="footer-group" aria-label="Contact">
+                <span>Contact</span>
+                <a href="about.html">About</a>
+                <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a>
+                <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer">X / Twitter</a>
+                <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer">Instagram</a>
+            </nav>
             <nav class="social-links">
                 <a href="https://x.com/Axylusion" target="_blank" rel="noopener noreferrer" title="X / Twitter" aria-label="X"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a>
                 <a href="https://www.instagram.com/axylusion" target="_blank" rel="noopener noreferrer" title="Instagram" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg></a>
@@ -158,6 +180,14 @@
                 <a href="https://suno.com/@axylusion" target="_blank" rel="noopener noreferrer" title="Suno" aria-label="Suno"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.5 14.5c0 .83-.67 1.5-1.5 1.5h-4c-.83 0-1.5-.67-1.5-1.5v-1c0-.83.67-1.5 1.5-1.5H14v-2h-4v1H8v-1c0-.83.67-1.5 1.5-1.5h4c.83 0 1.5.67 1.5 1.5v1c0 .83-.67 1.5-1.5 1.5H10v2h4v-1h1.5v1z"/></svg></a>
             </nav>
             <p class="footer-copyright">&copy; 2026 <a href="https://koltregaskes.com" target="_blank" rel="noopener noreferrer">Kol Tregaskes</a></p>
+            <section class="footer-estate-panel" aria-label="Elusion Works umbrella">
+                <div>
+                    <span>Umbrella home</span>
+                    <a class="footer-estate-title" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Elusion Works</a>
+                </div>
+                <p>The showcase for Kol's websites, tools, games, and web experiments.</p>
+                <a class="footer-estate-cta" href="https://elusionworks.com/" target="_blank" rel="noopener noreferrer">Visit Elusion Works -&gt;</a>
+            </section>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- add the shared footer link groups and Elusion Works umbrella panel to legacy support pages
- add a footer to the 404 page so every public HTML page has estate continuity
- adjust the legacy footer grid so copyright and the umbrella panel sit below the link columns without overlap

## Verification
- python scripts/validate-site.py
- PLAYWRIGHT_MODULE_PATH=W:\\Websites\\sites\\repo-foundry\\node_modules node scripts/smoke-test-site.mjs --base-url http://127.0.0.1:54832 --wait-ms 400
- Playwright desktop/mobile footer geometry check for 11 public pages